### PR TITLE
only remove KVO observer when view is loaded

### DIFF
--- a/Classes/ARGenericTableViewController.m
+++ b/Classes/ARGenericTableViewController.m
@@ -68,7 +68,9 @@
 
 - (void)dealloc
 {
-    [self.tableView removeObserver:self forKeyPath:@"editing"];
+    if (self.isViewLoaded) {
+      [self.tableView removeObserver:self forKeyPath:@"editing"];      
+    }
 }
 
 - (void)viewDidLoad


### PR DESCRIPTION
It is impossible to run tests against ARGenericViewController's behavior without loading the view, this checks that the view and KVO is set up before removing itself as an observer.